### PR TITLE
Use a pip compliant versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_package_data(package):
 
 setup(
     name='djangorestframework-filters',
-    version='0.10.2.post0.fix',
+    version='0.10.2.post0.dev0',
     url='http://github.com/philipn/django-rest-framework-filters',
     license='MIT',
     long_description=README,


### PR DESCRIPTION
According to https://www.python.org/dev/peps/pep-0440/#public-version-identifiers, the expected scheme is `[N!]N(.N)*[{a|b|rc}N][.postN][.devN]`

Going to rename this from `0.10.2.post0.fix` to `0.10.2.post0.dev0`